### PR TITLE
Potential fix for code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/agents/local_agent1/local_agent1.py
+++ b/agents/local_agent1/local_agent1.py
@@ -113,7 +113,8 @@ def run_script(payload: RunScript):
         }
 
     except Exception as e:
-        return JSONResponse(status_code=500, content={"error": str(e)})
+        logging.error(f"Exception in /run-script: {e}")
+        return JSONResponse(status_code=500, content={"error": "An internal server error occurred"})
 
 
 # Start agent if called

--- a/agents/local_agent2/local_agent2.py
+++ b/agents/local_agent2/local_agent2.py
@@ -75,7 +75,8 @@ def get_scripts():
         )
 
     except Exception as e:
-        return JSONResponse(status_code=500, content={"error": str(e)})
+        logging.error("An unexpected error occurred", exc_info=True)
+        return JSONResponse(status_code=500, content={"error": "An internal error has occurred."})
 
 
 # Run assigned script from script_manifest.json
@@ -106,7 +107,8 @@ def run_script(payload: RunScript):
         }
 
     except Exception as e:
-        return JSONResponse(status_code=500, content={"error": str(e)})
+        logging.error("An unexpected error occurred while running the script", exc_info=True)
+        return JSONResponse(status_code=500, content={"error": "An internal error has occurred."})
 
 
 # Start agent if called


### PR DESCRIPTION
Potential fix for [https://github.com/gustav0thethird/ScriptMesh/security/code-scanning/11](https://github.com/gustav0thethird/ScriptMesh/security/code-scanning/11)

To fix the issue, we need to ensure that detailed exception information, including stack traces, is not exposed to external users. Instead, we should log the exception details on the server for debugging purposes and return a generic error message to the user. This approach maintains security while still allowing developers to diagnose issues.

Specifically:
1. Replace the `str(e)` in the JSON response with a generic error message like `"An internal error has occurred."`.
2. Log the exception details (e.g., stack trace) using the `logging` module to ensure developers can access the information for debugging.
3. Apply this fix to all instances where exception details are exposed, including the `run-script` endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
