### PR TITLE
Potential fix for code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,13 +51,8 @@ AGENT_URLS = {
 def read_file(filename: str = Query(...)):
     base_dir = Path("/data").resolve()
 
-    # Normalize the filename to prevent directory traversal
-    normalized_filename = os.path.normpath(filename)
-    if ".." in normalized_filename or normalized_filename.startswith("/"):
-        raise HTTPException(status_code=400, detail="Invalid file path")
-
-    requested_path = (base_dir / normalized_filename).resolve()
-
+    # Combine and resolve the path, then check containment
+    requested_path = (base_dir / filename).resolve()
     try:
         requested_path.relative_to(base_dir)
     except ValueError:


### PR DESCRIPTION
Potential fix for [https://github.com/gustav0thethird/ScriptMesh/security/code-scanning/18](https://github.com/gustav0thethird/ScriptMesh/security/code-scanning/18)

To fix the problem, we should ensure that the user-provided filename is never used to construct a path outside the intended base directory. The best way is to join the base directory and the user input, normalize the resulting path, and then check that the resolved path is still within the base directory. This should all be done using `Path` methods for consistency. Specifically, we should:

- Combine the base directory and the user-provided filename using `Path(base_dir, filename)`.
- Resolve the resulting path to get its absolute form.
- Check that the resolved path is a subpath of the base directory using `relative_to`.
- Remove the redundant normalization and manual checks for `".."` and leading slashes, as the `relative_to` check is sufficient.

No new imports are needed, as `Path` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
